### PR TITLE
Remove the export of the AWS_REGION env var

### DIFF
--- a/saml2aws.plugin.zsh
+++ b/saml2aws.plugin.zsh
@@ -51,7 +51,7 @@ saml-role () {
     else
       export SAML2AWS_ROLE=${ROLE}
       export AWS_PROFILE=$(echo ${SAML2AWS_ROLE} | awk -F: '{print $5 ":" $6}')
-      export AWS_REGION=${SAML2AWS_REGION}
+      #export AWS_REGION=${SAML2AWS_REGION}
       export SAML2AWS_PROFILE=$AWS_PROFILE
       echo "SAML2AWS_ROLE=${SAML2AWS_ROLE}" > ~/.aws/default_role
       echo "AWS_PROFILE=${AWS_PROFILE}" >> ~/.aws/default_role


### PR DESCRIPTION
It most probably will end up being empty, which will break all the aws
commands. Instead, better to rely on the aws_region option in the local
aws config.