### PR TITLE
Introduce env var to set shorter AWS_PROFILE

### DIFF
--- a/saml2aws.plugin.zsh
+++ b/saml2aws.plugin.zsh
@@ -51,7 +51,11 @@ saml-role () {
     else
       [ -z ${SAML2AWS_REGION} ] || export AWS_REGION=${SAML2AWS_REGION}
       export SAML2AWS_ROLE=${ROLE}
-      export AWS_PROFILE=$(echo ${SAML2AWS_ROLE} | awk -F: '{print $5 ":" $6}')
+      if [ "$SAML2AWS_PROFILE_SHORT" = "true" ] ; then
+          export AWS_PROFILE=$(echo ${SAML2AWS_ROLE} | awk -F/ '{print $2}' | sed -e 's/-okta-/\//' -e 's/-saml-/\//' -e 's/-iam-role//')
+      else
+          export AWS_PROFILE=$(echo ${SAML2AWS_ROLE} | awk -F: '{print $5 ":" $6}')
+      fi
       export SAML2AWS_PROFILE=$AWS_PROFILE
       echo "SAML2AWS_ROLE=${SAML2AWS_ROLE}" > ~/.aws/default_role
       echo "AWS_PROFILE=${AWS_PROFILE}" >> ~/.aws/default_role


### PR DESCRIPTION
The AWS_PROFILE var is almost as big as the ARN of the role. Since I
don't want such a long AWS_PROFILE, as most of this info is not really
important for me to look at my starship, I am introducing the
SAML2AWS_PROFILE_SHORT env var. If it is set to true, then a shorter
AWS_PROFILE is set, which is in the format:

account_name/part_of_the_username